### PR TITLE
tmp fix: broken icon on linux (deb)

### DIFF
--- a/.afterPack.js
+++ b/.afterPack.js
@@ -1,0 +1,19 @@
+// The hook is a temporary fix to set the right icon size for the deb archive.
+// The hook only applies to the `deb` target.
+// The hook will set the icon size to 512 for all icons with a size of 0.
+// The hook can be removed once:
+// 1. The proper fix (https://github.com/develar/app-builder/pull/71) is merged.
+// 2. New versions of app-builder and app-builder-bin are released.
+// 3. A version of electron-builder with the fixed app-builder-bin is released.
+// 4. The electron-builder dev dependency is updated.
+exports.default = async function(context) {
+    context.targets.forEach(target => {
+        if (target.name !== "deb") { return }
+
+        target.helper.iconPromise.value = target.helper.iconPromise.value.then(
+            icons => icons.map(
+                icon => ({...icon, size: icon.size === 0 ? 512 : icon.size})
+            )
+        )
+    })
+}

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "productName": "Alephium",
     "directories": {
       "buildResources": "assets"
-    }
+    },
+    "afterPack": ".afterPack.js"
   },
   "engines": {
     "node": ">=12.0.0"


### PR DESCRIPTION
> This was previously [mentioned on discord](https://discord.com/channels/747741246667227157/878206973781368842/901966881068580964).

## Context

The icon is package incorrectly for linux (deb). This is due to a [bug in `app-builder`](https://github.com/develar/app-builder/issues/42) which is a dependency (wrapped as a npm module in [`app-builder-bin`](https://www.npmjs.com/package/app-builder-bin)) of electron-builder, the tool used for packaging.

There is a [fix for it](https://github.com/develar/app-builder/pull/71), but it hasn't been merged yet. And once it is the following must happened:
1. A new version of `app-builder` must be released with the fix, together with a new version of the js wrapper (`app-builder-bin`).
1. `electron-builder` must update its dependencies to include the new version of `app-builder-bin`.
1. A new version of `electron-builder` with the updated dependencies must be released.
1. The `electron-builder` dev dependency of `alephium-wallet` must be updated.
1. A new release of `alephium-wallet` can be released with the icon.

While I'm confident that you can do the last two points quite quickly (providing no breaking changes from `electron-builder`), all the former points may take some times and are outside this project's control. It's likely that this won't happen before the mainnet release. Hence I'm submitting this quick fix to manually set the icon size to `512` and package the icon correctly for the big day.

If you would like to avoid hacks and temporary fixes like this one, feel free to close the PR :wink: 

## Changes

This PR adds an [`afterPack` hook](https://www.electron.build/configuration/configuration#afterpack) which after gathering all the files for a `deb` archives, remaps all icons with a size of `0` to `512`.

Things to note:
- Any icon (I don't think there should be any other)  with a correct (non-`0`)  size will not be affected.  
- Any icon with a `0` size will be set to `512`. 
- Adding icons with a detected size of `0` and an actual size other than `512` will be *packaged incorrectly*.
- Once `app-builder` is fixed, the correct size of `512` should be detected and the hook should not have any effect. It can then be removed. (If it remains, it should have no effects, besides wasting some CPU cycles.)
