### PR TITLE
fix: set the app window icon on Linux

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -121,6 +121,10 @@ function createWindow() {
     titleBarStyle: process.platform === 'win32' ? 'default' : 'hidden'
   })
 
+  if (process.platform === 'linux') {
+    mainWindow.setIcon(path.join(__dirname, "icons/logo-48.png"))
+  }
+
   mainWindow.loadURL(isDev ? 'http://localhost:3000' : `file://${path.join(__dirname, '../build/index.html')}`)
   if (isDev) {
     // Open the DevTools.


### PR DESCRIPTION
Electron should use the executable icon as the default application
window. However this seems broken on Linux. This might be related to
https://github.com/alephium/alephium-wallet/pull/41

This sets the alephium icon for the application to be displayed by the
wm on the window decoration, on windows switchers, etc.

Notice the difference before (yellow line) and after on rofi
![2021-11-05-170151_3840x2081_scrot](https://user-images.githubusercontent.com/2848217/140541366-aebe2541-7314-45b6-8998-2ca7883b1865.png)
:
