### PR TITLE
Add a "localhost" preset for running the stack locally

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -190,6 +190,7 @@ const ClientSettings = () => {
   const networkSelectOptions: NetworkSelectOption[] = [
     { label: 'Mainnet', value: 'mainnet' },
     { label: 'Testnet', value: 'testnet' },
+    { label: 'Localhost', value: 'localhost' },
     { label: 'Custom', value: 'custom' }
   ]
 

--- a/src/utils/clients.ts
+++ b/src/utils/clients.ts
@@ -56,7 +56,7 @@ export interface Settings {
   explorerUrl: string
 }
 
-const networkTypes = ['testnet', 'mainnet'] as const
+const networkTypes = ['testnet', 'mainnet', 'localhost'] as const
 export type NetworkType = typeof networkTypes[number]
 
 export const networkEndpoints: Record<NetworkType, Settings> = {
@@ -69,6 +69,11 @@ export const networkEndpoints: Record<NetworkType, Settings> = {
     nodeHost: 'https://testnet-wallet.alephium.org',
     explorerApiHost: 'https://testnet-backend.alephium.org',
     explorerUrl: 'https://testnet.alephium.org'
+  },
+  localhost: {
+    nodeHost: 'http://localhost:12973',
+    explorerApiHost: 'http://localhost:9090',
+    explorerUrl: 'http://localhost:3000'
   }
 }
 


### PR DESCRIPTION
Preset to set default URLs when running the stack locally:

![image](https://user-images.githubusercontent.com/6715943/142995161-fb85441f-561e-4efd-bd76-d1713f5943e1.png)

Fixes #57 