### PR TITLE
Use softprops' release action & generate checksums in the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,10 @@ on:
     tags: ['v[0-9]+.[0-9]+.[0-9]+*']
 
 jobs:
-  release:
+  bump-npm-version:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get-version.outputs.VERSION }}
-      upload-url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -25,7 +24,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '16.x'
-      - name: Update version
+      - name: Update NPM version
         run: |
           git config --global user.name 'polarker'
           git config --global user.email 'polarker@users.noreply.github.com'
@@ -35,22 +34,12 @@ jobs:
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git commit -am "Bump to ${{ steps.get-version.outputs.VERSION }}"
           git push origin HEAD:master
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ steps.get-version.outputs.VERSION }}
-          release_name: v${{ steps.get-version.outputs.VERSION }}
-          body: Some solid code
-          draft: false
-          prerelease: false
-      - run: echo ${{ steps.create_release.outputs.upload_url }}
 
-  build-and-upload:
+  build-artifacts:
     runs-on: ${{ matrix.os }}
-    needs: release
+    needs: bump-npm-version
+    outputs:
+      version: ${{ needs.bump-npm-version.outputs.version }}
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
@@ -77,43 +66,73 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload release assets (macos)
-        uses: actions/upload-release-asset@v1
-        with:
-          upload_url: ${{ needs.release.outputs.upload-url }}
-          asset_path: dist/Alephium-${{ needs.release.outputs.version }}-universal.dmg
-          asset_name: alephium-wallet-macos-universal-${{ needs.release.outputs.version }}.dmg
-          asset_content_type: application/octet-stream
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload artifact (macos)
         if: startsWith(matrix.os, 'macos')
-      - name: Upload release assets (linux .deb)
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-artifact@v2
         with:
-          upload_url: ${{ needs.release.outputs.upload-url }}
-          asset_path: dist/alephium-wallet_${{ needs.release.outputs.version }}_amd64.deb
-          asset_name: alephium-wallet-linux-amd64-${{ needs.release.outputs.version }}.deb
-          asset_content_type: application/octet-stream
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: macos-binary
+          path: dist/Alephium-${{ needs.bump-npm-version.outputs.version }}-universal.dmg
+      - name: Upload artifact (linux .deb)
         if: startsWith(matrix.os, 'ubuntu')
-      - name: Upload release assets (linux AppImage)
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-artifact@v2
         with:
-          upload_url: ${{ needs.release.outputs.upload-url }}
-          asset_path: dist/Alephium-${{ needs.release.outputs.version }}.AppImage
-          asset_name: alephium-wallet-linux-${{ needs.release.outputs.version }}.AppImage
-          asset_content_type: application/octet-stream
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: deb-binary
+          path: dist/alephium-wallet_${{ needs.bump-npm-version.outputs.version }}_amd64.deb
+      - name: Upload artifact (linux .AppImage)
         if: startsWith(matrix.os, 'ubuntu')
-      - name: Upload release assets (macos)
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-artifact@v2
         with:
-          upload_url: ${{ needs.release.outputs.upload-url }}
-          asset_path: dist\Alephium Setup ${{ needs.release.outputs.version }}.exe
-          asset_name: alephium-wallet-windows-${{ needs.release.outputs.version }}.exe
-          asset_content_type: application/octet-stream
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: appimage-binary
+          path: dist/Alephium-${{ needs.bump-npm-version.outputs.version }}.AppImage
+      - name: Upload artifact (windows)
         if: startsWith(matrix.os, 'windows')
+        uses: actions/upload-artifact@v2
+        with:
+          name: windows-binary
+          path: dist\Alephium Setup ${{ needs.bump-npm-version.outputs.version }}.exe
+          
+  release:
+    runs-on: ubuntu-latest
+    needs: build-artifacts
+    steps:
+      - name: Get macos artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: macos-binary
+      - name: Get .deb artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: deb-binary
+      - name: Get .appimage artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: appimage-binary
+      - name: Get windows artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: windows-binary
+      - name: Generate wallet checksums (Release prep)
+        run: |
+             mv "Alephium-${{ needs.build-artifacts.outputs.version }}-universal.dmg" "alephium-wallet-macos-universal-${{ needs.build-artifacts.outputs.version }}.dmg"
+             mv "alephium-wallet_${{ needs.build-artifacts.outputs.version }}_amd64.deb" "alephium-wallet-linux-amd64-${{ needs.build-artifacts.outputs.version }}.deb"
+             mv "Alephium-${{ needs.build-artifacts.outputs.version }}.AppImage" "alephium-wallet-linux-${{ needs.build-artifacts.outputs.version }}.AppImage"
+             mv "Alephium Setup ${{ needs.build-artifacts.outputs.version }}.exe" "alephium-wallet-windows-${{ needs.build-artifacts.outputs.version }}.exe"
+             
+             sha256sum "alephium-wallet-macos-universal-${{ needs.build-artifacts.outputs.version }}.dmg" > "alephium-wallet-macos-universal-${{ needs.build-artifacts.outputs.version }}.dmg.checksum"
+             sha256sum "alephium-wallet-linux-amd64-${{ needs.build-artifacts.outputs.version }}.deb" > "alephium-wallet-linux-amd64-${{ needs.build-artifacts.outputs.version }}.deb.checksum"
+             sha256sum "alephium-wallet-linux-${{ needs.build-artifacts.outputs.version }}.AppImage" > "alephium-wallet-linux-${{ needs.build-artifacts.outputs.version }}.AppImage.checksum"
+             sha256sum "alephium-wallet-windows-${{ needs.build-artifacts.outputs.version }}.exe" > "alephium-wallet-windows-${{ needs.build-artifacts.outputs.version }}.exe.checksum"
+              
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            alephium-wallet-macos-universal-${{ needs.build-artifacts.outputs.version }}.dmg
+            alephium-wallet-macos-universal-${{ needs.build-artifacts.outputs.version }}.dmg.checksum
+            alephium-wallet-linux-amd64-${{ needs.build-artifacts.outputs.version }}.deb
+            alephium-wallet-linux-amd64-${{ needs.build-artifacts.outputs.version }}.deb.checksum
+            alephium-wallet-linux-${{ needs.build-artifacts.outputs.version }}.AppImage
+            alephium-wallet-linux-${{ needs.build-artifacts.outputs.version }}.AppImage.checksum
+            alephium-wallet-windows-${{ needs.build-artifacts.outputs.version }}.exe
+            alephium-wallet-windows-${{ needs.build-artifacts.outputs.version }}.exe.checksum
+    


### PR DESCRIPTION
Update the github action for release to use softprops' release action and compute checksums for every binary. 
Sample release available here : https://github.com/capito27/alephium-wallet/releases/tag/v9.9.12

NB : the worflow had to be slighly redesigned to work with softprops' action