### PR TITLE
Revert "Fix dev hot reloading issue with CSP"

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Alephium dev <dev@alephium.org>",
   "main": "public/electron.js",
   "scripts": {
-    "build": "cross-env REACT_APP_VERSION=$npm_package_version INLINE_RUNTIME_CHUNK=false REACT_APP_CSP=\"script-src 'self'\" react-scripts build",
+    "build": "cross-env REACT_APP_VERSION=$npm_package_version INLINE_RUNTIME_CHUNK=false react-scripts build",
     "electron-dev": "concurrently \"BROWSER=none npm run start\" \"wait-on http://localhost:3000 && electron .\"",
     "electron-pack": "npm run build && npx electron-builder",
     "electron-pack-windows": "npm run build && npx electron-builder -w",
@@ -14,7 +14,7 @@
     "electron-pack-ubuntu": "npm run build && npx electron-builder -l",
     "extension-build": "shx rm -rf build && npm run build && shx cp public/background.js public/manifest.json build",
     "extension-pack": "npm run extension-build && web-ext build --source-dir=build --artifacts-dir=. --filename=alephium-wallet.zip --overwrite-dest",
-    "start": "cross-env REACT_APP_VERSION=$npm_package_version REACT_APP_CSP=\"script-src 'self' 'unsafe-inline'\" react-scripts start",
+    "start": "cross-env REACT_APP_VERSION=$npm_package_version react-scripts start",
     "test": "react-scripts test",
     "lint": "eslint . --ext .ts,.tsx --max-warnings=0",
     "lint:fix": "eslint . --fix --ext .ts,.tsx",

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Official Alephium Wallet" />
-    <meta http-equiv="Content-Security-Policy" content="%REACT_APP_CSP%" />
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self';" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/apple-touch-icon.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
I went ahead and merged #82 (couldn't wait to rebase on this one ;)), to then realise that I have the following error:

```The Content-Security-Policy directive name '%REACT_APP_CSP%' contains one or more invalid characters. Only ASCII alphanumeric characters or dashes '-' are allowed in directive names.```

We could either revert directly, or fix this in the PR. As you prefer @nop33 