### PR TITLE
Simplify Paragraph component

### DIFF
--- a/src/components/Paragraph.tsx
+++ b/src/components/Paragraph.tsx
@@ -16,33 +16,55 @@
 
 import { HTMLMotionProps, motion, Variants } from 'framer-motion'
 import { FC } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
+
+interface ParagraphProps {
+  centered?: boolean
+  secondary?: boolean
+}
 
 const variants: Variants = {
   hidden: { y: 10, opacity: 0 },
   shown: { y: 0, opacity: 1 }
 }
 
-const Paragraph: FC<HTMLMotionProps<'p'>> = ({ children, className, style, ...props }) => {
+const Paragraph: FC<HTMLMotionProps<'p'> & ParagraphProps> = ({
+  centered,
+  secondary,
+  children,
+  className,
+  style,
+  ...props
+}) => {
   return (
-    <StyledParagraph variants={variants} className={className} style={style} {...props}>
+    <StyledParagraph
+      variants={variants}
+      className={className}
+      centered={centered}
+      secondary={secondary}
+      style={style}
+      {...props}
+    >
       {children}
     </StyledParagraph>
   )
 }
 
-const StyledParagraph = styled(motion.p)`
+const StyledParagraph = styled(motion.p)<ParagraphProps>`
   white-space: pre-wrap;
   font-weight: var(--fontWeight-medium);
-`
 
-export const CenteredMainParagraph = styled(Paragraph)`
-  text-align: center;
-`
+  ${({ centered }) =>
+    centered &&
+    css`
+      text-align: center;
+    `}
 
-export const CenteredSecondaryParagraph = styled(Paragraph)`
-  text-align: center;
-  color: ${({ theme }) => theme.font.secondary};
+  ${({ secondary, theme }) =>
+    secondary &&
+    css`
+      color: ${theme.font.secondary};
+    `}
 `
 
 export default Paragraph

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -26,7 +26,7 @@ import { deviceBreakPoints } from '../style/globalStyles'
 import { Input, Select } from '../components/Inputs'
 import { Button } from '../components/Buttons'
 import { MainPanel, PanelTitle, SectionContent } from '../components/PageComponents'
-import Paragraph, { CenteredSecondaryParagraph } from '../components/Paragraph'
+import Paragraph from '../components/Paragraph'
 import AppHeader from '../components/AppHeader'
 import SideBar from '../components/HomePage/SideBar'
 
@@ -58,9 +58,9 @@ const HomePage = ({ hasWallet, usernames }: HomeProps) => {
           {!showInitialActions && hasWallet && (
             <>
               <PanelTitle useLayoutId={false}>Welcome back!</PanelTitle>
-              <CenteredSecondaryParagraph>
+              <Paragraph centered secondary>
                 Please choose an account and enter your password to continue.
-              </CenteredSecondaryParagraph>
+              </Paragraph>
               <Login onLinkClick={displayInitialActions} usernames={usernames} />
             </>
           )}
@@ -150,9 +150,9 @@ const InitialActions = ({
 
   return (
     <>
-      <CenteredSecondaryParagraph>
+      <Paragraph centered secondary>
         Please choose whether you want to create a new wallet or import an existing one.
-      </CenteredSecondaryParagraph>
+      </Paragraph>
       <SectionContent inList>
         <Button onClick={() => history.push('/create')}>New wallet</Button>
         <Button onClick={() => history.push('/import')}>Import wallet</Button>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -26,7 +26,7 @@ import { Input, Select } from '../components/Inputs'
 import { PanelContainer, SectionContent } from '../components/PageComponents'
 import TabBar, { TabItem } from '../components/TabBar'
 import Modal from '../components/Modal'
-import { CenteredSecondaryParagraph } from '../components/Paragraph'
+import Paragraph from '../components/Paragraph'
 import ThemeSwitcher from '../components/ThemeSwitcher'
 import ExpandableSection from '../components/ExpandableSection'
 import { getNetworkName, networkEndpoints, NetworkType, Settings } from '../utils/settings'
@@ -123,9 +123,9 @@ const AccountSettings = () => {
               <div>
                 <SectionContent>
                   <Input value={typedPassword} placeholder="Password" type="password" onChange={handlePasswordChange} />
-                  <CenteredSecondaryParagraph>
+                  <Paragraph centered secondary>
                     Type your password above to show your 24 words phrase.
-                  </CenteredSecondaryParagraph>
+                  </Paragraph>
                 </SectionContent>
                 <SectionContent>
                   <Button onClick={() => handlePasswordVerification(() => setIsDisplayingPhrase(true))}>Show</Button>
@@ -155,9 +155,9 @@ const AccountSettings = () => {
                 text="Please make sure to have your secret phrase saved and stored somewhere secure to restore your wallet in the future. Without the 24 words, your wallet will be unrecoverable and permanently lost."
               />
 
-              <CenteredSecondaryParagraph>
+              <Paragraph centered secondary>
                 <b>Not your keys, not your coins.</b>
-              </CenteredSecondaryParagraph>
+              </Paragraph>
             </SectionContent>
             <SectionContent inList>
               <Button alert onClick={() => handleRemoveAccount()}>

--- a/src/pages/WalletManagement/CheckWordsIntroPage.tsx
+++ b/src/pages/WalletManagement/CheckWordsIntroPage.tsx
@@ -27,7 +27,7 @@ import {
   PanelTitle,
   SectionContent
 } from '../../components/PageComponents'
-import { CenteredMainParagraph, CenteredSecondaryParagraph } from '../../components/Paragraph'
+import Paragraph from '../../components/Paragraph'
 import { StepsContext } from '../MultiStepsController'
 
 import { ReactComponent as LockHandleSVG } from '../../images/lock_handle.svg'
@@ -58,8 +58,10 @@ const CheckWordsIntroPage = () => {
                 </LockBodyContainer>
               </Lock>
             </LockContainer>
-            <CenteredMainParagraph>Alright! Time to check if you got your words right!</CenteredMainParagraph>
-            <CenteredSecondaryParagraph>Select the words in the right order. Ready?</CenteredSecondaryParagraph>
+            <Paragraph centered>Alright! Time to check if you got your words right!</Paragraph>
+            <Paragraph secondary centered>
+              Select the words in the right order. Ready?
+            </Paragraph>
           </SectionContent>
         </PanelContent>
         <FooterActions apparitionDelay={0.3}>

--- a/src/pages/WalletManagement/ImportWordsPage.tsx
+++ b/src/pages/WalletManagement/ImportWordsPage.tsx
@@ -31,7 +31,7 @@ import {
   SectionContent
 } from '../../components/PageComponents'
 import { Button } from '../../components/Buttons'
-import { CenteredSecondaryParagraph } from '../../components/Paragraph'
+import Paragraph from '../../components/Paragraph'
 import { bip39Words } from '../../utils/bip39'
 
 const Storage = getStorage()
@@ -102,11 +102,11 @@ const ImportWordsPage = () => {
               onChange={handlePhraseChange}
             />
           </SectionContent>
-          <CenteredSecondaryParagraph>
+          <Paragraph centered secondary>
             {!isNextButtonActive()
               ? 'Make sure to properly write down the 24 words from your secret phrase. They are the key to your wallet.'
               : "All good? Let's continue!"}
-          </CenteredSecondaryParagraph>
+          </Paragraph>
         </PanelContent>
         <FooterActions>
           <Button secondary onClick={onButtonBack}>


### PR DESCRIPTION
A short cleaning PR. We can now use 1 `Paragraph` component with simple props (`centered`, `secondary`) instead of 3 different components.

Side-note: I cherry-picked a2323e25a0e6ded4a5fc6df435f2820a4129debf as the gas-price feature will have to wait for the OpenAPI to be updated (`gasPrice` format is incorrect.)

