### PR TITLE
Fix error display

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -20,6 +20,7 @@ import { tryGetString } from './types'
 
 interface APIError {
   error: {
+    detail?: string
     message?: string
   }
   status: number
@@ -32,5 +33,7 @@ export const isHTTPError = (e: unknown): e is APIError => {
 
 export const getHumanReadableError = (e: unknown, defaultErrorMessage: string) => {
   const stringifiedError = tryGetString(e)
-  return isHTTPError(e) ? `(${e.status}: ${e.statusText}) ${e.error.message}` : stringifiedError || defaultErrorMessage
+  return isHTTPError(e)
+    ? e.error.detail || `(${e.status}: ${e.statusText}) ${e.error.message || ''}`
+    : `${defaultErrorMessage}${stringifiedError && `(${stringifiedError})`}`
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -19,7 +19,11 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { tryGetString } from './types'
 
 interface APIError {
-  error: { detail: string }
+  error: {
+    message?: string
+  }
+  status: number
+  statusText: string
 }
 
 export const isHTTPError = (e: unknown): e is APIError => {
@@ -28,5 +32,5 @@ export const isHTTPError = (e: unknown): e is APIError => {
 
 export const getHumanReadableError = (e: unknown, defaultErrorMessage: string) => {
   const stringifiedError = tryGetString(e)
-  return isHTTPError(e) ? e.error.detail : stringifiedError || defaultErrorMessage
+  return isHTTPError(e) ? `(${e.status}: ${e.statusText}) ${e.error.message}` : stringifiedError || defaultErrorMessage
 }


### PR DESCRIPTION
I discovered that when the explorer backend gives a 500 error, our current error handling does not display any information (see image). This PR fixes this problem.

| before | after |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/1579899/147121972-7dd0d508-44c1-4aa2-bfd3-796969201d32.png) | ![image](https://user-images.githubusercontent.com/1579899/147122014-67c54d55-fe80-43da-819a-f844a236d25f.png) |
