### PR TITLE
Clear password and mnemonic after account creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/jest": "^27.0.2",
         "@types/lodash": "^4.14.173",
         "@types/node": "^16.9.6",
-        "@types/react": "^17.0.24",
+        "@types/react": "^17.0.39",
         "@types/react-color": "^3.0.6",
         "@types/react-dom": "^17.0.9",
         "@types/react-router-dom": "^5.3.0",
@@ -4940,9 +4940,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.37",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.37.tgz",
-      "integrity": "sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==",
+      "version": "17.0.39",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
+      "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -37381,9 +37381,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.37",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.37.tgz",
-      "integrity": "sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==",
+      "version": "17.0.39",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
+      "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/jest": "^27.0.2",
     "@types/lodash": "^4.14.173",
     "@types/node": "^16.9.6",
-    "@types/react": "^17.0.24",
+    "@types/react": "^17.0.39",
     "@types/react-color": "^3.0.6",
     "@types/react-dom": "^17.0.9",
     "@types/react-router-dom": "^5.3.0",

--- a/src/components/PasswordConfirmation.tsx
+++ b/src/components/PasswordConfirmation.tsx
@@ -17,9 +17,9 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { getStorage, walletOpen } from 'alephium-js'
-import { useState } from 'react'
 
 import { useGlobalContext } from '../contexts/global'
+import { useWalletContext } from '../contexts/wallet'
 import Button from './Button'
 import Input from './Inputs/Input'
 import { Section } from './PageComponents/PageContainers'
@@ -41,13 +41,14 @@ const PasswordConfirmation = ({
   accountName
 }: PasswordConfirmationProps) => {
   const { currentAccountName, setSnackbarMessage } = useGlobalContext()
-  const [password, setPassword] = useState('')
+  const { password, setPassword } = useWalletContext()
 
   const validatePassword = () => {
     const walletEncrypted = Storage.load(accountName || currentAccountName)
 
     try {
       if (walletOpen(password, walletEncrypted)) {
+        setPassword('')
         onCorrectPasswordEntered(password)
       }
     } catch (e) {

--- a/src/pages/WalletManagement/CheckWordsPage.tsx
+++ b/src/pages/WalletManagement/CheckWordsPage.tsx
@@ -46,7 +46,7 @@ interface WordKey {
 }
 
 const CheckWordsPage = () => {
-  const { mnemonic, plainWallet, password, accountName } = useWalletContext()
+  const { mnemonic, plainWallet, password, accountName, setMnemonic, setPassword } = useWalletContext()
   const { onButtonBack, onButtonNext } = useStepsContext()
   const { setSnackbarMessage } = useGlobalContext()
 
@@ -186,6 +186,8 @@ const CheckWordsPage = () => {
     if (areWordsValid && plainWallet) {
       const walletEncrypted = plainWallet.encrypt(password)
       Storage.save(accountName, walletEncrypted)
+      setPassword('')
+      setMnemonic('')
       setWallet(plainWallet)
       return true
     }


### PR DESCRIPTION
After account creation, the password given and the mnemonic created were being
left in memory even after the wallet is locked. This commit moves the password
and mnemonic management completely to the WalletContext and clears them at the
appropriate times.