### PR TITLE
WIP: Require password after some minutes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/jest": "^27.0.2",
         "@types/lodash": "^4.14.173",
         "@types/node": "^16.9.6",
-        "@types/react": "^17.0.24",
+        "@types/react": "^17.0.39",
         "@types/react-color": "^3.0.6",
         "@types/react-dom": "^17.0.9",
         "@types/react-router-dom": "^5.3.0",
@@ -4940,9 +4940,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.37",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.37.tgz",
-      "integrity": "sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==",
+      "version": "17.0.39",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
+      "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -37381,9 +37381,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.37",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.37.tgz",
-      "integrity": "sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==",
+      "version": "17.0.39",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
+      "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/jest": "^27.0.2",
     "@types/lodash": "^4.14.173",
     "@types/node": "^16.9.6",
-    "@types/react": "^17.0.24",
+    "@types/react": "^17.0.39",
     "@types/react-color": "^3.0.6",
     "@types/react-dom": "^17.0.9",
     "@types/react-router-dom": "^5.3.0",

--- a/src/components/AccountSummaryCard.tsx
+++ b/src/components/AccountSummaryCard.tsx
@@ -29,7 +29,11 @@ const AccountSummaryCard = ({ className }: { className?: string }) => {
 
   const totalBalance = addresses.reduce((acc, address) => acc + BigInt(address.details.balance), BigInt(0))
   const totalAvailableBalance = addresses.reduce((acc, address) => acc + address.availableBalance, BigInt(0))
-  const totalLockedBalance = addresses.reduce((acc, address) => acc + BigInt(address.details.lockedBalance), BigInt(0))
+  const totalLockedBalance = addresses.reduce((acc: bigint | undefined, { details: { lockedBalance } }) => {
+    if (acc === undefined) return acc
+    if (lockedBalance === undefined) return undefined
+    return acc + BigInt(lockedBalance)
+  }, BigInt(0))
 
   return (
     <div className={className}>

--- a/src/components/PasswordConfirmation.tsx
+++ b/src/components/PasswordConfirmation.tsx
@@ -48,7 +48,6 @@ const PasswordConfirmation = ({
 
     try {
       if (walletOpen(password, walletEncrypted)) {
-        setPassword('')
         onCorrectPasswordEntered(password)
       }
     } catch (e) {

--- a/src/components/PasswordConfirmation.tsx
+++ b/src/components/PasswordConfirmation.tsx
@@ -17,9 +17,9 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { getStorage, walletOpen } from 'alephium-js'
-import { useState } from 'react'
 
 import { useGlobalContext } from '../contexts/global'
+import { useWalletContext } from '../contexts/wallet'
 import Button from './Button'
 import Input from './Inputs/Input'
 import { Section } from './PageComponents/PageContainers'
@@ -41,13 +41,14 @@ const PasswordConfirmation = ({
   accountName
 }: PasswordConfirmationProps) => {
   const { currentAccountName, setSnackbarMessage } = useGlobalContext()
-  const [password, setPassword] = useState('')
+  const { password, setPassword } = useWalletContext()
 
   const validatePassword = () => {
     const walletEncrypted = Storage.load(accountName || currentAccountName)
 
     try {
       if (walletOpen(password, walletEncrypted)) {
+        setPassword('')
         onCorrectPasswordEntered(password)
       }
     } catch (e) {

--- a/src/hooks/timers.ts
+++ b/src/hooks/timers.ts
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { createContext, useContext } from 'react'
+
+export enum Timer {
+  PasswordReconfirmation = 'password_reconfirmation'
+}
+
+interface TimerContext {
+  timers: Map<string, Date>
+}
+
+const context = createContext<TimerContext>({ timers: new Map() })
+
+//
+// A global timer is necessary since time must be tracked across all states of
+// the application.
+//
+export const useGlobalTimer = (name: string, waitUntil = 0): [number, () => void] => {
+  const { timers } = useContext(context)
+
+  let start = timers.get(name)
+  if (start === undefined) {
+    start = new Date()
+    timers.set(name, start)
+  }
+
+  const now = new Date()
+
+  const timeLeftInMillis = Math.max(0, waitUntil - (now.getTime() - start.getTime()))
+  return [
+    timeLeftInMillis,
+
+    // A mechanism to reset a timer at any point
+    () => timers.set(name, new Date())
+  ]
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,6 +27,7 @@ import { ThemeProvider } from 'styled-components'
 import App from './App'
 import { AddressesContextProvider } from './contexts/addresses'
 import { GlobalContextProvider } from './contexts/global'
+import { WalletContextProvider } from './contexts/wallet'
 import * as serviceWorker from './serviceWorker'
 import { GlobalStyle } from './style/globalStyles'
 import { lightTheme } from './style/themes'
@@ -35,12 +36,14 @@ ReactDOM.render(
   <React.StrictMode>
     <Router>
       <GlobalContextProvider>
-        <AddressesContextProvider>
-          <ThemeProvider theme={lightTheme}>
-            <GlobalStyle />
-            <App />
-          </ThemeProvider>
-        </AddressesContextProvider>
+        <WalletContextProvider>
+          <AddressesContextProvider>
+            <ThemeProvider theme={lightTheme}>
+              <GlobalStyle />
+              <App />
+            </ThemeProvider>
+          </AddressesContextProvider>
+        </WalletContextProvider>
       </GlobalContextProvider>
     </Router>
   </React.StrictMode>,

--- a/src/modals/SecretPhraseModal.tsx
+++ b/src/modals/SecretPhraseModal.tsx
@@ -16,6 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { decrypt } from 'alephium-js/dist/lib/password-crypto'
 import { Edit3 } from 'lucide-react'
 import { useState } from 'react'
 import styled from 'styled-components'
@@ -24,11 +25,19 @@ import InfoBox from '../components/InfoBox'
 import { Section } from '../components/PageComponents/PageContainers'
 import PasswordConfirmation from '../components/PasswordConfirmation'
 import { useGlobalContext } from '../contexts/global'
+import { useWalletContext } from '../contexts/wallet'
 import CenteredModal from './CenteredModal'
 
 const SecretPhraseModal = ({ onClose }: { onClose: () => void }) => {
   const { wallet } = useGlobalContext()
+  const { password, setPassword } = useWalletContext()
   const [isDisplayingPhrase, setIsDisplayingPhrase] = useState(false)
+
+  let mnemonic
+  if (password && wallet) {
+    mnemonic = decrypt(password, wallet.mnemonicEncrypted)
+    setPassword('')
+  }
 
   return (
     <CenteredModal title="Secret phrase" onClose={onClose} focusMode>
@@ -47,7 +56,7 @@ const SecretPhraseModal = ({ onClose }: { onClose: () => void }) => {
             Icon={Edit3}
             importance="alert"
           />
-          <PhraseBox>{wallet?.mnemonic || 'No mnemonic was stored along with this wallet'}</PhraseBox>
+          <PhraseBox>{mnemonic || 'No mnemonic was stored along with this wallet'}</PhraseBox>
         </Section>
       )}
     </CenteredModal>

--- a/src/modals/SendModal/index.tsx
+++ b/src/modals/SendModal/index.tsx
@@ -24,6 +24,7 @@ import { useEffect, useState } from 'react'
 import PasswordConfirmation from '../../components/PasswordConfirmation'
 import { Address, useAddressesContext } from '../../contexts/addresses'
 import { useGlobalContext } from '../../contexts/global'
+import { useWalletContext } from '../../contexts/wallet'
 import { Timer, useGlobalTimer } from '../../hooks/timers'
 import { ReactComponent as PaperPlaneSVG } from '../../images/paper-plane.svg'
 import { getHumanReadableError, isHTTPError } from '../../utils/api'
@@ -58,6 +59,7 @@ const SendModal = ({ onClose }: SendModalProps) => {
     }
   } = useGlobalContext()
   const { setAddress } = useAddressesContext()
+  const { password, setPassword } = useWalletContext()
   const [timeToAuth, resetTimeToAuth] = useGlobalTimer(Timer.PasswordReconfirmation, passwordReconfirmationTimeInMillis)
   const [title, setTitle] = useState('')
   const [transactionData, setTransactionData] = useState<SendTransactionData | undefined>()
@@ -162,6 +164,11 @@ const SendModal = ({ onClose }: SendModalProps) => {
     buildConsolidationTransactions()
   }, [client, consolidationRequired, transactionData])
 
+  const onCorrectPasswordEntered = (password: string) => {
+    setPassword(password)
+    handleSend()
+  }
+
   const handleSend = async () => {
     if (!transactionData || !client) return
 
@@ -183,6 +190,7 @@ const SendModal = ({ onClose }: SendModalProps) => {
 
           for (const { txId, unsignedTx } of sweepUnsignedTxs) {
             const data = await client.signAndSendTransaction(
+              password,
               fromAddress,
               txId,
               unsignedTx,
@@ -197,6 +205,7 @@ const SendModal = ({ onClose }: SendModalProps) => {
           }
         } else {
           const data = await client.signAndSendTransaction(
+            password,
             fromAddress,
             unsignedTxId,
             unsignedTransaction,
@@ -244,7 +253,7 @@ const SendModal = ({ onClose }: SendModalProps) => {
         <PasswordConfirmation
           text="Enter your password to send the transaction."
           buttonText="Send"
-          onCorrectPasswordEntered={handleSend}
+          onCorrectPasswordEntered={onCorrectPasswordEntered}
         />
       )}
       <AnimatePresence>

--- a/src/modals/SettingsModal/GeneralSettingsSection.tsx
+++ b/src/modals/SettingsModal/GeneralSettingsSection.tsx
@@ -26,7 +26,7 @@ import { useGlobalContext } from '../../contexts/global'
 const GeneralSettingsSection = () => {
   const {
     settings: {
-      general: { walletLockTimeInMinutes, discreetMode, passwordRequirement }
+      general: { walletLockTimeInMinutes, discreetMode, passwordReconfirmationTimeInMillis }
     },
     updateSettings
   } = useGlobalContext()
@@ -66,11 +66,19 @@ const GeneralSettingsSection = () => {
       <HorizontalDivider narrow />
       <KeyValueInput
         label="Password requirement"
-        description="Require password confirmation before sending each transaction."
+        description="Require password confirmation again after some minutes."
         InputComponent={
-          <Toggle
-            toggled={passwordRequirement}
-            onToggle={() => updateSettings('general', { passwordRequirement: !passwordRequirement })}
+          <Input
+            value={Math.floor(passwordReconfirmationTimeInMillis / 1000 / 60) || ''}
+            onChange={(v) =>
+              updateSettings('general', {
+                passwordReconfirmationTimeInMillis: v.target.value ? parseInt(v.target.value) * 1000 * 60 : 0
+              })
+            }
+            placeholder={passwordReconfirmationTimeInMillis ? 'Minutes' : 'Every time'}
+            type="number"
+            step={1}
+            min={1}
           />
         }
       />

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -84,18 +84,18 @@ interface LoginProps {
 }
 
 const Login = ({ accountNames, onLinkClick }: LoginProps) => {
-  const [credentials, setCredentials] = useState({ accountName: '', password: '' })
   const { login } = useGlobalContext()
+  const [password, setPassword] = useState('')
+  const [accountName, setAccountName] = useState('')
   const history = useHistory()
 
-  const handleCredentialsChange = useCallback((type: 'accountName' | 'password', value: string) => {
-    setCredentials((prev) => ({ ...prev, [type]: value }))
-  }, [])
-
-  const handleLogin = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    e.preventDefault()
-    login(credentials.accountName, credentials.password, () => history.push('/wallet/overview'))
-  }
+  const handleLogin = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      e.preventDefault()
+      login(accountName, password, () => history.push('/wallet/overview'))
+    },
+    [accountName, password, history, login]
+  )
 
   return (
     <>
@@ -103,7 +103,7 @@ const Login = ({ accountNames, onLinkClick }: LoginProps) => {
         <Select
           placeholder="Account"
           options={accountNames.map((u) => ({ label: u, value: u }))}
-          onValueChange={(value) => handleCredentialsChange('accountName', value?.value || '')}
+          onValueChange={(value) => setAccountName(value?.value || '')}
           title="Select an account"
           id="account"
         />
@@ -111,13 +111,13 @@ const Login = ({ accountNames, onLinkClick }: LoginProps) => {
           placeholder="Password"
           type="password"
           autoComplete="off"
-          onChange={(e) => handleCredentialsChange('password', e.target.value)}
-          value={credentials.password}
+          onChange={(e) => setPassword(e.target.value)}
+          value={password}
           id="password"
         />
       </SectionStyled>
       <SectionStyled inList>
-        <Button onClick={handleLogin} submit disabled={!credentials.accountName || !credentials.password}>
+        <Button onClick={handleLogin} submit disabled={!accountName || !password}>
           Login
         </Button>
       </SectionStyled>

--- a/src/pages/WalletManagement/CheckWordsPage.tsx
+++ b/src/pages/WalletManagement/CheckWordsPage.tsx
@@ -46,7 +46,7 @@ interface WordKey {
 }
 
 const CheckWordsPage = () => {
-  const { mnemonic, plainWallet, password, accountName } = useWalletContext()
+  const { mnemonic, plainWallet, password, accountName, setMnemonic, setPassword } = useWalletContext()
   const { onButtonBack, onButtonNext } = useStepsContext()
   const { setSnackbarMessage } = useGlobalContext()
 
@@ -186,6 +186,8 @@ const CheckWordsPage = () => {
     if (areWordsValid && plainWallet) {
       const walletEncrypted = plainWallet.encrypt(password)
       Storage.save(accountName, walletEncrypted)
+      setPassword('')
+      setMnemonic('')
       setWallet(plainWallet)
       return true
     }

--- a/src/pages/WalletManagement/CheckWordsPage.tsx
+++ b/src/pages/WalletManagement/CheckWordsPage.tsx
@@ -37,6 +37,7 @@ import Paragraph from '../../components/Paragraph'
 import { useGlobalContext } from '../../contexts/global'
 import { useStepsContext } from '../../contexts/steps'
 import { useWalletContext } from '../../contexts/wallet'
+import { scrubWallet, toWalletSecureSecrets } from '../../utils/wallet'
 
 const Storage = getStorage()
 
@@ -46,7 +47,7 @@ interface WordKey {
 }
 
 const CheckWordsPage = () => {
-  const { mnemonic, plainWallet, password, accountName, setMnemonic, setPassword } = useWalletContext()
+  const { mnemonic, plainWallet, password, accountName, setMnemonic } = useWalletContext()
   const { onButtonBack, onButtonNext } = useStepsContext()
   const { setSnackbarMessage } = useGlobalContext()
 
@@ -186,9 +187,13 @@ const CheckWordsPage = () => {
     if (areWordsValid && plainWallet) {
       const walletEncrypted = plainWallet.encrypt(password)
       Storage.save(accountName, walletEncrypted)
-      setPassword('')
+
+      // setPassword('') happens a bit later in the process.
+
       setMnemonic('')
-      setWallet(plainWallet)
+      const secureWallet = toWalletSecureSecrets(password, plainWallet)
+      scrubWallet(plainWallet)
+      setWallet(secureWallet)
       return true
     }
   }

--- a/src/pages/WalletManagement/ImportWordsPage.tsx
+++ b/src/pages/WalletManagement/ImportWordsPage.tsx
@@ -35,6 +35,7 @@ import { useStepsContext } from '../../contexts/steps'
 import { useWalletContext } from '../../contexts/wallet'
 import { getHumanReadableError } from '../../utils/api'
 import { bip39Words } from '../../utils/bip39'
+import { scrubWallet, toWalletSecureSecrets } from '../../utils/wallet'
 
 const Storage = getStorage()
 
@@ -71,12 +72,12 @@ const ImportWordsPage = () => {
       .replace(/,/g, ' ')
 
     try {
-      const wallet = walletImport(formatedPhrase)
-
-      setWallet(wallet)
-
-      const encryptedWallet = wallet.encrypt(password)
+      const plainWallet = walletImport(formatedPhrase)
+      const encryptedWallet = plainWallet.encrypt(password)
       Storage.save(accountName, encryptedWallet)
+
+      scrubWallet(plainWallet)
+      setWallet(toWalletSecureSecrets(password, plainWallet))
 
       onButtonNext()
     } catch (e) {

--- a/src/routes/CreateWalletRoutes.tsx
+++ b/src/routes/CreateWalletRoutes.tsx
@@ -19,7 +19,6 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import AppHeader from '../components/AppHeader'
 import FloatingLogo from '../components/FloatingLogo'
 import { StepsContextProvider } from '../contexts/steps'
-import { WalletContextProvider } from '../contexts/wallet'
 import CheckWordsIntroPage from '../pages/WalletManagement/CheckWordsIntroPage'
 import CheckWordsPage from '../pages/WalletManagement/CheckWordsPage'
 import CreateAccountPage from '../pages/WalletManagement/CreateAccountPage'
@@ -36,11 +35,11 @@ const CreateWalletRoutes = () => {
   ]
 
   return (
-    <WalletContextProvider>
+    <>
       <AppHeader />
       <FloatingLogo />
       <StepsContextProvider stepElements={createWalletSteps} baseUrl={'create'} />
-    </WalletContextProvider>
+    </>
   )
 }
 

--- a/src/routes/ImportWalletRoutes.tsx
+++ b/src/routes/ImportWalletRoutes.tsx
@@ -19,7 +19,6 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import AppHeader from '../components/AppHeader'
 import FloatingLogo from '../components/FloatingLogo'
 import { StepsContextProvider } from '../contexts/steps'
-import { WalletContextProvider } from '../contexts/wallet'
 import CreateAccountPage from '../pages/WalletManagement/CreateAccountPage'
 import ImportWordsPage from '../pages/WalletManagement/ImportWordsPage'
 import WalletWelcomePage from '../pages/WalletManagement/WalletWelcomePage'
@@ -32,11 +31,11 @@ const ImportWalletRoutes = () => {
   ]
 
   return (
-    <WalletContextProvider>
+    <>
       <AppHeader />
       <FloatingLogo />
       <StepsContextProvider stepElements={importWalletSteps} baseUrl="import" />
-    </WalletContextProvider>
+    </>
   )
 }
 

--- a/src/tests/settings.test.ts
+++ b/src/tests/settings.test.ts
@@ -33,7 +33,7 @@ const mockSettings = {
     theme: 'light' as ThemeType,
     walletLockTimeInMinutes: 999,
     discreetMode: false,
-    passwordRequirement: false
+    passwordReconfirmationTimeInMillis: 1000 * 60 * 10
   },
   network: {
     nodeHost: 'https://node',

--- a/src/utils/api-clients.ts
+++ b/src/utils/api-clients.ts
@@ -17,6 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { CliqueClient, ExplorerClient } from 'alephium-js'
+import { decrypt } from 'alephium-js/dist/lib/password-crypto'
 
 import { Address, AddressHash, TransactionType } from '../contexts/addresses'
 import { NetworkType, Settings } from './settings'
@@ -102,6 +103,7 @@ export async function createClient(settings: Settings['network']) {
     }
 
     const signAndSendTransaction = async (
+      password: string,
       address: Address,
       txId: string,
       unsignedTx: string,
@@ -110,7 +112,8 @@ export async function createClient(settings: Settings['network']) {
       network: NetworkType,
       amount?: bigint
     ) => {
-      const signature = cliqueClient.transactionSign(txId, address.privateKey)
+      const privateKey = decrypt(password, address.privateKeyEncrypted)
+      const signature = cliqueClient.transactionSign(txId, privateKey)
       const response = await cliqueClient.transactionSend(toHash, unsignedTx, signature)
 
       if (response.data) {

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -25,7 +25,7 @@ export interface Settings {
     theme: ThemeType
     walletLockTimeInMinutes: number | null
     discreetMode: boolean
-    passwordRequirement: boolean
+    passwordReconfirmationTimeInMillis: number
   }
   network: {
     nodeHost: string
@@ -64,7 +64,7 @@ export const defaultSettings: Settings = {
     theme: 'light',
     walletLockTimeInMinutes: 3,
     discreetMode: false,
-    passwordRequirement: false
+    passwordReconfirmationTimeInMillis: 10
   },
   network: clone(networkEndpoints.mainnet)
 }

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -1,0 +1,64 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { Wallet } from 'alephium-js'
+import { encrypt } from 'alephium-js/dist/lib/password-crypto'
+
+//
+// It's important to be explicit about what exactly is secure in this wallet, to
+// avoid the developer assumption that the address and public key are also
+// encrypted / secured.
+//
+export interface WalletSecureSecrets {
+  address: string
+  publicKey: string
+  privateKeyEncrypted: string
+  seed: Buffer
+  mnemonicEncrypted: string
+}
+
+export const scrubWallet = (wallet: Wallet) => {
+  Object.assign(wallet, {
+    address: '',
+    publicKey: '',
+    privateKey: '',
+    mnemonic: ''
+  })
+  wallet.seed.fill(0)
+}
+
+export const scrubWalletSecureSecrets = (wallet: WalletSecureSecrets) => {
+  Object.assign(wallet, {
+    address: '',
+    publicKey: '',
+    privateKeyEncrypted: '',
+    mnemonicEncrypted: ''
+  })
+  wallet.seed.fill(0)
+}
+
+export const toWalletSecureSecrets = (
+  password: string,
+  { address, publicKey, privateKey, seed, mnemonic }: Wallet
+): WalletSecureSecrets => ({
+  address,
+  publicKey,
+  privateKeyEncrypted: encrypt(password, privateKey),
+  seed: Buffer.from(seed),
+  mnemonicEncrypted: encrypt(password, mnemonic)
+})


### PR DESCRIPTION
  The wallet's private keys are currently exposed for the entire duration of the
  account being unlocked. While this is a nice user experience it is not security
  oriented. As an alternative, the wallet's private keys will be available for
  additional signing for a certain amount of adjustable time after a transaction.
  Each subsequent transaction will reset the timer. This enables users to continue
  to view their funds, while keeping their private keys safe.

This PR still has to be sufficiently tested. I'm having difficulty mixing my local testnet node and the official testnet explorer backend.